### PR TITLE
bug/status history 

### DIFF
--- a/api/applicants.py
+++ b/api/applicants.py
@@ -437,8 +437,8 @@ def update_applicant_status(user_code):
 
     success, message = update_applicant_application_status(user_code, status)
 
-    # Log the status change
-    if success:
+    # Log the status change only if the status actually changed
+    if success and old_status != status:
         log_activity(
             action_type="status_change",
             target_entity="applicant",

--- a/api/logs.py
+++ b/api/logs.py
@@ -73,12 +73,14 @@ def get_logs():
     offset = int(request.args.get("offset", 0))
     action_filter = request.args.get("action_type")
     user_search = request.args.get("user_search")
+    target_id = request.args.get("target_id")
 
     logs, error = get_activity_logs(
         limit=limit,
         offset=offset,
         filter_action_type=action_filter,
         filter_user_search=user_search,
+        filter_target_id=target_id,
     )
 
     if error:

--- a/utils/activity_logger.py
+++ b/utils/activity_logger.py
@@ -85,7 +85,7 @@ def log_activity(
 
 
 def get_activity_logs(
-    limit=50, offset=0, filter_action_type=None, filter_user_search=None
+    limit=50, offset=0, filter_action_type=None, filter_user_search=None, filter_target_id=None
 ):
     """Get activity logs with optional filtering"""
     conn = get_db_connection()
@@ -105,6 +105,10 @@ def get_activity_logs(
         if filter_action_type:
             where_conditions = ["action_type = %s"]  # Override the IN clause
             params = [filter_action_type]
+
+        if filter_target_id:
+            where_conditions.append("al.target_id = %s")
+            params.append(filter_target_id)
 
         if filter_user_search:
             where_conditions.append("(u.first_name ILIKE %s OR u.last_name ILIKE %s)")


### PR DESCRIPTION
Fix status history logging and filtering
                                                                                             
   -Status history no longer updates on unrelated saves, the status change activity log     
  entry is now only written when the status value actually changes, not every time ratings or
   prerequisites are saved with the same status.
  - Status history now filters by applicant, the target_id query parameter sent by the
  frontend was being ignored by the API and never passed to the database query. The history
  panel in the applicant modal now correctly shows only that applicant's status changes
  instead of all applicants.