### PR TITLE
added export log feature

### DIFF
--- a/api/logs.py
+++ b/api/logs.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
 from utils.activity_logger import get_activity_logs
+from utils.db_helpers import fetch_all
+from utils.csv_helpers import create_csv_response, generate_export_filename
 
 logs_api = Blueprint("logs_api", __name__)
 
@@ -95,3 +97,71 @@ def get_logs():
             "offset": offset,
         }
     )
+
+
+@logs_api.route("/logs/export/status-changes", methods=["GET"])
+@login_required
+def export_status_changes():
+    """Export applicant status change logs as a CSV file.
+
+    Returns all status_change activity log entries as a downloadable CSV.
+    Optionally filtered to a specific admin's changes via user_id query param.
+
+    @requires: Admin authentication
+    @method: GET
+    @param user_id: Filter by admin user ID (query param, optional)
+    @param_type user_id: int
+
+    @return: CSV file attachment
+    @status_codes:
+        - 200: CSV file returned
+        - 403: Access denied (non-Admin user)
+        - 500: Database or generation error
+    """
+    if not current_user.is_authenticated or not current_user.is_admin:
+        return jsonify({"success": False, "message": "Access denied"}), 403
+
+    user_ids_param = request.args.get("user_ids", "")
+    user_ids = [int(uid) for uid in user_ids_param.split(",") if uid.strip().isdigit()]
+
+    try:
+        where_clause = "WHERE al.action_type = 'status_change'"
+        params = []
+        if user_ids:
+            placeholders = ",".join(["%s"] * len(user_ids))
+            where_clause += f" AND al.user_id IN ({placeholders})"
+            params.extend(user_ids)
+
+        rows = fetch_all(
+            f"""
+            SELECT al.created_at, u.first_name, u.last_name, u.email,
+                   al.target_id, al.old_value, al.new_value
+            FROM activity_log al
+            LEFT JOIN "user" u ON al.user_id = u.id
+            {where_clause}
+            ORDER BY al.created_at DESC
+            """,
+            params if params else None,
+        )
+
+        fieldnames = ["Date/Time", "Admin Name", "Admin Email", "Applicant Code", "Old Status", "New Status"]
+
+        export_rows = []
+        for row in rows:
+            first = row["first_name"]
+            last = row["last_name"]
+            admin_name = f"{first} {last}".strip() if (first or last) else "Unknown User"
+            export_rows.append({
+                "Date/Time": row["created_at"].strftime("%Y-%m-%d %H:%M:%S") if row["created_at"] else "",
+                "Admin Name": admin_name,
+                "Admin Email": row["email"] or "",
+                "Applicant Code": row["target_id"] or "",
+                "Old Status": row["old_value"] or "",
+                "New Status": row["new_value"] or "",
+            })
+
+        filename = generate_export_filename("status_change_logs", len(export_rows))
+        return create_csv_response(export_rows, filename, fieldnames)
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -15,6 +15,11 @@ class LogsManager {
     this.maxLogs = 50; // Maximum logs total (also might need to change in logs.py)
     this.totalPages = 1;
     this.currentFilters = {};
+    this.selectedExportUserIds = new Set();
+    this.exportUsers = [];
+    this.currentDisplayedUserIds = [];
+    this.exportSortField = "name";
+    this.exportSortDir = "asc";
 
     this.initializeEventListeners();
     this.loadInitialData();
@@ -45,6 +50,55 @@ class LogsManager {
     document.getElementById("userSearch").addEventListener("keypress", (e) => {
       if (e.key === "Enter") {
         this.applyFilters();
+      }
+    });
+
+    document.getElementById("exportStatusChangesBtn").addEventListener("click", () => {
+      this.showExportModal();
+    });
+
+    document.getElementById("closeExportModal").addEventListener("click", () => {
+      this.closeExportModal();
+    });
+
+    document.getElementById("cancelExportBtn").addEventListener("click", () => {
+      this.closeExportModal();
+    });
+
+    document.getElementById("exportAllBtn").addEventListener("click", () => {
+      this.exportStatusChanges(null);
+    });
+
+    document.getElementById("exportForAdminBtn").addEventListener("click", () => {
+      if (this.selectedExportUserIds.size > 0) {
+        this.exportStatusChanges([...this.selectedExportUserIds]);
+      }
+    });
+
+    document.getElementById("exportSelectAllCheckbox").addEventListener("change", (e) => {
+      this.toggleSelectAllExportUsers(e.target.checked);
+    });
+
+    document.getElementById("exportAdminSearch").addEventListener("input", (e) => {
+      this.filterExportUsers(e.target.value.trim());
+    });
+
+    document.getElementById("exportSortNameTh").addEventListener("click", () => {
+      this.sortExportUsers("name");
+    });
+
+    document.getElementById("exportSortEmailTh").addEventListener("click", () => {
+      this.sortExportUsers("email");
+    });
+
+    document.getElementById("exportSortRoleTh").addEventListener("click", () => {
+      this.sortExportUsers("role");
+    });
+
+    // Close modal on backdrop click
+    document.getElementById("exportStatusChangesModal").addEventListener("click", (e) => {
+      if (e.target === document.getElementById("exportStatusChangesModal")) {
+        this.closeExportModal();
       }
     });
   }
@@ -314,5 +368,293 @@ class LogsManager {
         <p class="text-red-600">Error: ${message}</p>
       </div>
     `;
+  }
+
+  showExportModal() {
+    this.selectedExportUserIds = new Set();
+    this.exportSortField = "name";
+    this.exportSortDir = "asc";
+    document.getElementById("exportAdminSearch").value = "";
+    document.getElementById("selectedAdminText").classList.add("hidden");
+    document.getElementById("exportForAdminBtn").disabled = true;
+    document.getElementById("exportForAdminBtn").textContent = "Export for Selected";
+    document.getElementById("exportSelectAllCheckbox").checked = false;
+    document.getElementById("exportSelectAllCheckbox").indeterminate = false;
+    this.resetExportSortIcons();
+
+    const modal = document.getElementById("exportStatusChangesModal");
+    modal.classList.remove("hidden");
+    modal.classList.add("flex");
+
+    this.loadExportUsers();
+  }
+
+  closeExportModal() {
+    const modal = document.getElementById("exportStatusChangesModal");
+    modal.classList.add("hidden");
+    modal.classList.remove("flex");
+  }
+
+  async loadExportUsers() {
+    document.getElementById("exportUsersTableBody").innerHTML = `
+      <tr><td colspan="5" class="px-4 py-6 text-center text-sm text-gray-500">Loading users...</td></tr>
+    `;
+
+    try {
+      const response = await fetch("/api/auth/users");
+      const result = await response.json();
+
+      if (result.success) {
+        this.exportUsers = result.users;
+        this.renderExportUsersTable(this.exportUsers);
+      } else {
+        document.getElementById("exportUsersTableBody").innerHTML = `
+          <tr><td colspan="5" class="px-4 py-6 text-center text-sm text-red-500">Failed to load users</td></tr>
+        `;
+      }
+    } catch (error) {
+      console.error("Error loading users:", error);
+      document.getElementById("exportUsersTableBody").innerHTML = `
+        <tr><td colspan="5" class="px-4 py-6 text-center text-sm text-red-500">Failed to load users</td></tr>
+      `;
+    }
+  }
+
+  filterExportUsers(query) {
+    if (!query) {
+      this.renderExportUsersTable(this.exportUsers);
+      return;
+    }
+
+    const q = query.toLowerCase();
+    const filtered = this.exportUsers.filter(
+      (u) =>
+        u.full_name.toLowerCase().includes(q) ||
+        u.email.toLowerCase().includes(q) ||
+        this.getExportRoleName(u.role_id).toLowerCase().includes(q)
+    );
+    this.renderExportUsersTable(filtered);
+  }
+
+  sortExportUsers(field) {
+    if (this.exportSortField === field) {
+      this.exportSortDir = this.exportSortDir === "asc" ? "desc" : "asc";
+    } else {
+      this.exportSortField = field;
+      this.exportSortDir = "asc";
+    }
+
+    this.resetExportSortIcons();
+    const icon = document.getElementById(
+      `exportSort${field.charAt(0).toUpperCase() + field.slice(1)}Icon`
+    );
+    if (icon) {
+      icon.textContent = this.exportSortDir === "asc" ? "↑" : "↓";
+      icon.classList.replace("text-gray-400", "text-blue-600");
+    }
+
+    const query = document.getElementById("exportAdminSearch").value.trim();
+    const q = query.toLowerCase();
+    const source = q
+      ? this.exportUsers.filter(
+          (u) =>
+            u.full_name.toLowerCase().includes(q) ||
+            u.email.toLowerCase().includes(q) ||
+            this.getExportRoleName(u.role_id).toLowerCase().includes(q)
+        )
+      : [...this.exportUsers];
+
+    source.sort((a, b) => {
+      let aVal, bVal;
+      if (field === "name") { aVal = a.full_name; bVal = b.full_name; }
+      else if (field === "email") { aVal = a.email; bVal = b.email; }
+      else { aVal = this.getExportRoleName(a.role_id); bVal = this.getExportRoleName(b.role_id); }
+
+      return this.exportSortDir === "asc"
+        ? aVal.localeCompare(bVal)
+        : bVal.localeCompare(aVal);
+    });
+
+    this.renderExportUsersTable(source);
+  }
+
+  resetExportSortIcons() {
+    ["Name", "Email", "Role"].forEach((f) => {
+      const icon = document.getElementById(`exportSort${f}Icon`);
+      if (icon) {
+        icon.textContent = "⇅";
+        icon.classList.replace("text-blue-600", "text-gray-400");
+      }
+    });
+  }
+
+  renderExportUsersTable(users) {
+    const tbody = document.getElementById("exportUsersTableBody");
+    this.currentDisplayedUserIds = users ? users.map((u) => u.id) : [];
+
+    if (!users || users.length === 0) {
+      tbody.innerHTML = `
+        <tr><td colspan="5" class="px-4 py-6 text-center text-sm text-gray-500">No users found</td></tr>
+      `;
+      this.updateSelectAllCheckbox();
+      return;
+    }
+
+    tbody.innerHTML = users
+      .map((user) => {
+        const initials = user.full_name
+          .split(" ")
+          .map((n) => n[0])
+          .join("")
+          .toUpperCase()
+          .slice(0, 2);
+        const isSelected = this.selectedExportUserIds.has(user.id);
+
+        return `
+          <tr
+            class="hover:bg-blue-50 cursor-pointer transition-colors ${isSelected ? "bg-blue-50" : ""}"
+            data-user-id="${user.id}"
+          >
+            <td class="px-4 py-3 w-8">
+              <input type="checkbox" class="export-user-checkbox w-4 h-4 text-blue-600 border-gray-300 rounded cursor-pointer"
+                data-user-id="${user.id}" ${isSelected ? "checked" : ""}>
+            </td>
+            <td class="px-4 py-3 whitespace-nowrap">
+              <div class="flex items-center">
+                <div class="flex-shrink-0 h-8 w-8 bg-blue-100 rounded-full flex items-center justify-center">
+                  <span class="text-blue-600 text-xs font-semibold">${initials}</span>
+                </div>
+                <div class="ml-3 text-sm font-medium text-gray-900">${user.full_name}</div>
+              </div>
+            </td>
+            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900">${user.email}</td>
+            <td class="px-4 py-3 whitespace-nowrap">
+              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${this.getExportRoleBadge(user.role_id)}">
+                ${this.getExportRoleName(user.role_id)}
+              </span>
+            </td>
+            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+              ${new Date(user.created_at).toLocaleDateString()}
+            </td>
+          </tr>
+        `;
+      })
+      .join("");
+
+    tbody.querySelectorAll("tr[data-user-id]").forEach((row) => {
+      row.addEventListener("click", (e) => {
+        if (e.target.type === "checkbox") return;
+        const cb = row.querySelector(".export-user-checkbox");
+        cb.checked = !cb.checked;
+        this.toggleExportAdmin(parseInt(row.dataset.userId), cb.checked);
+      });
+    });
+
+    tbody.querySelectorAll(".export-user-checkbox").forEach((cb) => {
+      cb.addEventListener("change", (e) => {
+        e.stopPropagation();
+        this.toggleExportAdmin(parseInt(cb.dataset.userId), cb.checked);
+      });
+    });
+
+    this.updateSelectAllCheckbox();
+  }
+
+  getExportRoleName(roleId) {
+    switch (roleId) {
+      case 1: return "Admin";
+      case 2: return "Faculty";
+      case 3: return "Viewer";
+      default: return "Unknown";
+    }
+  }
+
+  getExportRoleBadge(roleId) {
+    switch (roleId) {
+      case 1: return "bg-purple-100 text-purple-800";
+      case 2: return "bg-blue-100 text-blue-800";
+      case 3: return "bg-gray-100 text-gray-800";
+      default: return "bg-gray-100 text-gray-800";
+    }
+  }
+
+  toggleExportAdmin(userId, checked) {
+    if (checked) {
+      this.selectedExportUserIds.add(userId);
+    } else {
+      this.selectedExportUserIds.delete(userId);
+    }
+
+    // Update row highlight without re-rendering
+    const row = document.querySelector(`tr[data-user-id="${userId}"]`);
+    if (row) {
+      row.classList.toggle("bg-blue-50", checked);
+    }
+
+    this.updateSelectAllCheckbox();
+    this.updateExportSelectionUI();
+  }
+
+  toggleSelectAllExportUsers(checked) {
+    this.currentDisplayedUserIds.forEach((id) => {
+      if (checked) {
+        this.selectedExportUserIds.add(id);
+      } else {
+        this.selectedExportUserIds.delete(id);
+      }
+      const row = document.querySelector(`tr[data-user-id="${id}"]`);
+      if (row) {
+        row.classList.toggle("bg-blue-50", checked);
+        const cb = row.querySelector(".export-user-checkbox");
+        if (cb) cb.checked = checked;
+      }
+    });
+    this.updateExportSelectionUI();
+  }
+
+  updateSelectAllCheckbox() {
+    const selectAll = document.getElementById("exportSelectAllCheckbox");
+    if (!selectAll || this.currentDisplayedUserIds.length === 0) return;
+
+    const selectedCount = this.currentDisplayedUserIds.filter((id) =>
+      this.selectedExportUserIds.has(id)
+    ).length;
+
+    selectAll.checked = selectedCount === this.currentDisplayedUserIds.length;
+    selectAll.indeterminate =
+      selectedCount > 0 && selectedCount < this.currentDisplayedUserIds.length;
+  }
+
+  updateExportSelectionUI() {
+    const count = this.selectedExportUserIds.size;
+    const btn = document.getElementById("exportForAdminBtn");
+    const text = document.getElementById("selectedAdminText");
+
+    if (count === 0) {
+      btn.disabled = true;
+      btn.textContent = "Export for Selected";
+      text.classList.add("hidden");
+    } else {
+      btn.disabled = false;
+      btn.textContent = `Export for Selected (${count})`;
+      text.textContent = `${count} admin${count !== 1 ? "s" : ""} selected`;
+      text.classList.remove("hidden");
+    }
+  }
+
+  exportStatusChanges(userIds) {
+    const url =
+      userIds && userIds.length > 0
+        ? `/api/logs/export/status-changes?user_ids=${userIds.join(",")}`
+        : "/api/logs/export/status-changes";
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    this.closeExportModal();
   }
 }

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -68,6 +68,9 @@
               <span id="logsCount" class="text-sm text-gray-600"
                 >Loading...</span
               >
+              <button id="exportStatusChangesBtn" class="btn-ubc text-sm">
+                Export Status Changes
+              </button>
               <button id="refreshLogs" class="btn-ubc-outline text-sm">
                 Refresh
               </button>
@@ -103,6 +106,76 @@
           </div>
         </section>
       </main>
+    </div>
+
+    <!-- Export Status Changes Modal -->
+    <div id="exportStatusChangesModal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
+      <div class="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 p-6">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg font-semibold text-ubc-blue">Export Status Change Logs</h3>
+          <button id="closeExportModal" class="text-gray-400 hover:text-gray-600 text-2xl font-bold leading-none">&times;</button>
+        </div>
+
+        <p class="text-sm text-gray-600 mb-4">
+          Export all applicant status change logs as a CSV file. Select an admin to filter by their changes, or export all.
+        </p>
+
+        <!-- Search Bar -->
+        <div class="mb-3">
+          <div class="relative">
+            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+              </svg>
+            </div>
+            <input
+              type="text"
+              id="exportAdminSearch"
+              placeholder="Search by name, email, or role..."
+              class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <!-- Users Table -->
+        <div class="border border-gray-200 rounded-lg overflow-hidden mb-4" style="max-height: 300px; overflow-y: auto;">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50 sticky top-0 z-10">
+              <tr>
+                <th class="px-4 py-3 w-8">
+                  <input type="checkbox" id="exportSelectAllCheckbox" class="w-4 h-4 text-blue-600 border-gray-300 rounded cursor-pointer" title="Select all">
+                </th>
+                <th id="exportSortNameTh" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none">
+                  <div class="flex items-center gap-1">User <span id="exportSortNameIcon" class="text-gray-400">⇅</span></div>
+                </th>
+                <th id="exportSortEmailTh" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none">
+                  <div class="flex items-center gap-1">Email <span id="exportSortEmailIcon" class="text-gray-400">⇅</span></div>
+                </th>
+                <th id="exportSortRoleTh" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none">
+                  <div class="flex items-center gap-1">Role <span id="exportSortRoleIcon" class="text-gray-400">⇅</span></div>
+                </th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              </tr>
+            </thead>
+            <tbody id="exportUsersTableBody" class="bg-white divide-y divide-gray-200">
+              <tr>
+                <td colspan="4" class="px-4 py-6 text-center text-sm text-gray-500">Loading users...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Selected Admin -->
+        <p id="selectedAdminText" class="text-sm text-ubc-blue mb-4 hidden"></p>
+
+        <!-- Action Buttons -->
+        <div class="flex gap-3 justify-end">
+          <button id="cancelExportBtn" class="btn-ubc-outline">Cancel</button>
+          <button id="exportForAdminBtn" class="btn-ubc-outline" disabled>Export for This Admin</button>
+          <button id="exportAllBtn" class="btn-ubc">Export All</button>
+        </div>
+      </div>
     </div>
 
     <!-- Session Management Scripts - Load before auth -->


### PR DESCRIPTION
Summary                                                                                  
                                                                                           
  - Adds a CSV export for applicant review status change logs from the Activity Logs page  
  - Admins can export all status changes, or filter by selecting one or more admins via a  
  searchable, sortable user table                                                          
  - New endpoint: GET /api/logs/export/status-changes?user_ids=1,2,3                       
                                                                                           
  CSV columns                                                                              
                                                                                           
  Date/Time, Admin Name, Admin Email, Applicant Code, Old Status, New Status  