### PR TITLE
added fix for status change direction

### DIFF
--- a/api/logs.py
+++ b/api/logs.py
@@ -46,10 +46,14 @@ def get_status_change_history():
         session_id = request.args.get("session_id", type=int)
         if not session_id:
             return jsonify({"success": False, "message": "session_id is required"}), 400
+        direction = request.args.get("direction") or None
+        if direction and direction not in ("to", "from", "both"):
+            direction = None
         rows = _service.get_status_change_history(
             session_id=session_id,
             status_filter=request.args.get("status") or None,
             accepted_filter=request.args.get("accepted_filter") or None,
+            direction=direction,
         )
         return jsonify({"success": True, "history": rows, "count": len(rows)})
     except Exception as e:

--- a/models/logs.py
+++ b/models/logs.py
@@ -7,7 +7,7 @@ Database queries for activity log data, joined with applicant information.
 from utils.db_helpers import db_connection
 
 
-def get_status_change_history(session_id, status_filter=None, accepted_filter=None):
+def get_status_change_history(session_id, status_filter=None, accepted_filter=None, direction=None):
     """
     Get all instances where an applicant was moved to a given status,
     joined with their current applicant data.
@@ -23,9 +23,16 @@ def get_status_change_history(session_id, status_filter=None, accepted_filter=No
 
             status_clause = ""
             if status_filter:
-                status_clause = "AND (al.new_value = %s OR al.old_value = %s)"
-                params.append(status_filter)
-                params.append(status_filter)
+                if direction == "to":
+                    status_clause = "AND al.new_value = %s"
+                    params.append(status_filter)
+                elif direction == "from":
+                    status_clause = "AND al.old_value = %s"
+                    params.append(status_filter)
+                else:
+                    status_clause = "AND (al.new_value = %s OR al.old_value = %s)"
+                    params.append(status_filter)
+                    params.append(status_filter)
 
             accepted_clause = ""
             if accepted_filter == "accepted":

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -23,10 +23,10 @@ class LogService:
             raise ValueError(error)
         return logs or []
 
-    def get_status_change_history(self, session_id: int, status_filter=None, accepted_filter=None) -> list:
+    def get_status_change_history(self, session_id: int, status_filter=None, accepted_filter=None, direction=None) -> list:
         """Return status change history for a session, with optional filters."""
         from models.logs import get_status_change_history as _query
-        rows, error = _query(session_id, status_filter, accepted_filter)
+        rows, error = _query(session_id, status_filter, accepted_filter, direction)
         if error:
             raise ValueError(error)
         return rows or []

--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -541,12 +541,17 @@ class StatisticsManager {
     }
 
     const statusFilter = document.getElementById("historyStatusFilter");
+    const directionFilter = document.getElementById("historyDirectionFilter");
     const acceptedFilter = document.getElementById("historyAcceptedFilter");
-    const searchInput = document.getElementById("historySearch");
     if (statusFilter)
       statusFilter.addEventListener("change", () => this.loadStatusHistory());
+    if (directionFilter)
+      directionFilter.addEventListener("change", () =>
+        this.loadStatusHistory(),
+      );
     if (acceptedFilter)
       acceptedFilter.addEventListener("change", () => this.loadStatusHistory());
+    const searchInput = document.getElementById("historySearch");
     if (searchInput)
       searchInput.addEventListener("input", () => this._applySearchAndRender());
 
@@ -568,6 +573,8 @@ class StatisticsManager {
 
     const statusFilter =
       document.getElementById("historyStatusFilter")?.value || "";
+    const directionFilter =
+      document.getElementById("historyDirectionFilter")?.value || "";
     const acceptedFilter =
       document.getElementById("historyAcceptedFilter")?.value || "";
 
@@ -579,6 +586,7 @@ class StatisticsManager {
     try {
       const params = { session_id: sessionId };
       if (statusFilter) params.status = statusFilter;
+      if (statusFilter && directionFilter) params.direction = directionFilter;
       if (acceptedFilter) params.accepted_filter = acceptedFilter;
 
       const result = await api.get("/api/logs/status-history", params);

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -343,6 +343,18 @@
           </div>
           <div>
             <label
+              for="historyDirectionFilter"
+              class="block text-sm font-medium text-gray-700 mb-1"
+              >Direction</label
+            >
+            <select id="historyDirectionFilter" class="input-ubc w-36">
+              <option value="">Both</option>
+              <option value="to">To Status</option>
+              <option value="from">From Status</option>
+            </select>
+          </div>
+          <div>
+            <label
               for="historyAcceptedFilter"
               class="block text-sm font-medium text-gray-700 mb-1"
               >Acceptance</label


### PR DESCRIPTION
Summary                                                                                   
                                                                                       
  Adds a direction filter to the status change history on the statistics page. Previously,  
  filtering by a status would return results where that status appeared in either the "from"
   or "to" column. Now users can choose to filter by "To Status", "From Status", or "Both"  
  (default) using a new dropdown placed between the Status and Acceptance filters.     
                                         
  Changes

  Backend: Updated the status history query in models/logs.py to accept a direction         
  parameter that controls whether to match on new_value, old_value, or both. Threaded the
  parameter through the service layer and API endpoint with validation.                     
                                                                                       
  Frontend: Added the Direction dropdown to the filter bar in statistics.html and wired it  
  up in statistics.js to pass the parameter on API calls. The filter has no effect when "All
   Statuses" is selected.          