### PR TITLE
added filtered student #

### DIFF
--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -646,6 +646,25 @@ class StatisticsManager {
   _renderHistoryTable(rows) {
     const tbody = document.getElementById("statusHistoryTableBody");
     if (!tbody) return;
+
+    const countEl = document.getElementById("historyResultCount");
+    const countWrapper = document.getElementById("historyResultCountWrapper");
+    const statusFilter =
+      document.getElementById("historyStatusFilter")?.value || "";
+    const searchVal =
+      document.getElementById("historySearch")?.value.trim() || "";
+    const isFiltering = !!statusFilter || !!searchVal;
+
+    if (countEl && countWrapper) {
+      countWrapper.style.display = isFiltering ? "" : "none";
+      if (isFiltering) {
+        const filterLabel = statusFilter
+          ? ` (filtered by: <strong>${statusFilter}</strong>)`
+          : "";
+        countEl.innerHTML = `Showing <span class="font-semibold">${rows.length}</span> of <span class="font-semibold">${this.historyData.length}</span> results${filterLabel}`;
+      }
+    }
+
     if (rows.length === 0) {
       tbody.innerHTML = `
         <tr>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -365,6 +365,16 @@
               <option value="not_accepted">Not Accepted</option>
             </select>
           </div>
+          <div
+            class="ml-auto self-end"
+            id="historyResultCountWrapper"
+            style="display: none"
+          >
+            <div
+              class="text-sm text-gray-600 bg-blue-50 px-4 py-2 rounded-lg"
+              id="historyResultCount"
+            ></div>
+          </div>
         </div>
 
         <!-- Search Bar -->


### PR DESCRIPTION
Status Change History Improvements

  Added a direction filter to the status change history on the statistics page. When
  filtering by a status it was returning results for both changes going to and from that
  status making it hard to tell what you were actually looking at. Now you can specify
  whether you want to see changes going to a status, coming from it, or both which is still
  the default.

  Also added a result counter to the filter bar that shows up when you have any filters or
  search active. It matches the same style as the applicants page showing how many results
  you're seeing out of the total.

  Both the direction and acceptance filters now have a short description below the label so
  it's clear what each one does without having to guess.

  Changes

  Backend updated the status history query to accept a direction param controlling whether
  it matches on new_value, old_value, or both. Threaded through service and API with input
  validation.

  Frontend added the direction dropdown, result counter with the blue pill styling, and
  helper text on the direction and acceptance filters.