### PR TITLE
status from and status to filters for change history

### DIFF
--- a/api/logs.py
+++ b/api/logs.py
@@ -46,14 +46,11 @@ def get_status_change_history():
         session_id = request.args.get("session_id", type=int)
         if not session_id:
             return jsonify({"success": False, "message": "session_id is required"}), 400
-        direction = request.args.get("direction") or None
-        if direction and direction not in ("to", "from", "both"):
-            direction = None
         rows = _service.get_status_change_history(
             session_id=session_id,
-            status_filter=request.args.get("status") or None,
+            status_from=request.args.get("status_from") or None,
+            status_to=request.args.get("status_to") or None,
             accepted_filter=request.args.get("accepted_filter") or None,
-            direction=direction,
         )
         return jsonify({"success": True, "history": rows, "count": len(rows)})
     except Exception as e:

--- a/models/logs.py
+++ b/models/logs.py
@@ -7,7 +7,7 @@ Database queries for activity log data, joined with applicant information.
 from utils.db_helpers import db_connection
 
 
-def get_status_change_history(session_id, status_filter=None, accepted_filter=None, direction=None):
+def get_status_change_history(session_id, status_from=None, status_to=None, accepted_filter=None):
     """
     Get all instances where an applicant was moved to a given status,
     joined with their current applicant data.
@@ -22,17 +22,12 @@ def get_status_change_history(session_id, status_filter=None, accepted_filter=No
             params = [session_id]
 
             status_clause = ""
-            if status_filter:
-                if direction == "to":
-                    status_clause = "AND al.new_value = %s"
-                    params.append(status_filter)
-                elif direction == "from":
-                    status_clause = "AND al.old_value = %s"
-                    params.append(status_filter)
-                else:
-                    status_clause = "AND (al.new_value = %s OR al.old_value = %s)"
-                    params.append(status_filter)
-                    params.append(status_filter)
+            if status_from:
+                status_clause += " AND al.old_value = %s"
+                params.append(status_from)
+            if status_to:
+                status_clause += " AND al.new_value = %s"
+                params.append(status_to)
 
             accepted_clause = ""
             if accepted_filter == "accepted":

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -23,10 +23,10 @@ class LogService:
             raise ValueError(error)
         return logs or []
 
-    def get_status_change_history(self, session_id: int, status_filter=None, accepted_filter=None, direction=None) -> list:
+    def get_status_change_history(self, session_id: int, status_from=None, status_to=None, accepted_filter=None) -> list:
         """Return status change history for a session, with optional filters."""
         from models.logs import get_status_change_history as _query
-        rows, error = _query(session_id, status_filter, accepted_filter, direction)
+        rows, error = _query(session_id, status_from, status_to, accepted_filter)
         if error:
             raise ValueError(error)
         return rows or []

--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -530,25 +530,27 @@ class StatisticsManager {
   }
 
   initStatusHistory() {
-    const statusSelect = document.getElementById("historyStatusFilter");
-    if (statusSelect) {
-      this.statusOptions.forEach((status) => {
-        const option = document.createElement("option");
-        option.value = status.status_name;
-        option.textContent = status.status_name;
-        statusSelect.appendChild(option);
-      });
-    }
+    ["historyStatusFromFilter", "historyStatusToFilter"].forEach((id) => {
+      const select = document.getElementById(id);
+      if (select) {
+        this.statusOptions.forEach((status) => {
+          const option = document.createElement("option");
+          option.value = status.status_name;
+          option.textContent = status.status_name;
+          select.appendChild(option);
+        });
+      }
+    });
 
-    const statusFilter = document.getElementById("historyStatusFilter");
-    const directionFilter = document.getElementById("historyDirectionFilter");
+    const statusFromFilter = document.getElementById("historyStatusFromFilter");
+    const statusToFilter = document.getElementById("historyStatusToFilter");
     const acceptedFilter = document.getElementById("historyAcceptedFilter");
-    if (statusFilter)
-      statusFilter.addEventListener("change", () => this.loadStatusHistory());
-    if (directionFilter)
-      directionFilter.addEventListener("change", () =>
+    if (statusFromFilter)
+      statusFromFilter.addEventListener("change", () =>
         this.loadStatusHistory(),
       );
+    if (statusToFilter)
+      statusToFilter.addEventListener("change", () => this.loadStatusHistory());
     if (acceptedFilter)
       acceptedFilter.addEventListener("change", () => this.loadStatusHistory());
     const searchInput = document.getElementById("historySearch");
@@ -571,10 +573,10 @@ class StatisticsManager {
       return;
     }
 
-    const statusFilter =
-      document.getElementById("historyStatusFilter")?.value || "";
-    const directionFilter =
-      document.getElementById("historyDirectionFilter")?.value || "";
+    const statusFrom =
+      document.getElementById("historyStatusFromFilter")?.value || "";
+    const statusTo =
+      document.getElementById("historyStatusToFilter")?.value || "";
     const acceptedFilter =
       document.getElementById("historyAcceptedFilter")?.value || "";
 
@@ -585,8 +587,8 @@ class StatisticsManager {
 
     try {
       const params = { session_id: sessionId };
-      if (statusFilter) params.status = statusFilter;
-      if (statusFilter && directionFilter) params.direction = directionFilter;
+      if (statusFrom) params.status_from = statusFrom;
+      if (statusTo) params.status_to = statusTo;
       if (acceptedFilter) params.accepted_filter = acceptedFilter;
 
       const result = await api.get("/api/logs/status-history", params);
@@ -649,18 +651,21 @@ class StatisticsManager {
 
     const countEl = document.getElementById("historyResultCount");
     const countWrapper = document.getElementById("historyResultCountWrapper");
-    const statusFilter =
-      document.getElementById("historyStatusFilter")?.value || "";
+    const statusFrom =
+      document.getElementById("historyStatusFromFilter")?.value || "";
+    const statusTo =
+      document.getElementById("historyStatusToFilter")?.value || "";
     const searchVal =
       document.getElementById("historySearch")?.value.trim() || "";
-    const isFiltering = !!statusFilter || !!searchVal;
+    const isFiltering = !!statusFrom || !!statusTo || !!searchVal;
 
     if (countEl && countWrapper) {
       countWrapper.style.display = isFiltering ? "" : "none";
       if (isFiltering) {
-        const filterLabel = statusFilter
-          ? ` (filtered by: <strong>${statusFilter}</strong>)`
-          : "";
+        const parts = [];
+        if (statusFrom) parts.push(`From: <strong>${statusFrom}</strong>`);
+        if (statusTo) parts.push(`To: <strong>${statusTo}</strong>`);
+        const filterLabel = parts.length ? ` (${parts.join(", ")})` : "";
         countEl.innerHTML = `Showing <span class="font-semibold">${rows.length}</span> of <span class="font-semibold">${this.historyData.length}</span> results${filterLabel}`;
       }
     }

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -333,24 +333,22 @@
         >
           <div>
             <label
-              for="historyStatusFilter"
+              for="historyStatusFromFilter"
               class="block text-sm font-medium text-gray-700 mb-1"
-              >Status</label
+              >Status From</label
             >
-            <select id="historyStatusFilter" class="input-ubc w-64">
+            <select id="historyStatusFromFilter" class="input-ubc w-56">
               <option value="">All Statuses</option>
             </select>
           </div>
           <div>
             <label
-              for="historyDirectionFilter"
+              for="historyStatusToFilter"
               class="block text-sm font-medium text-gray-700 mb-1"
-              >Direction</label
+              >Status To</label
             >
-            <select id="historyDirectionFilter" class="input-ubc w-36">
-              <option value="">Both</option>
-              <option value="to">To Status</option>
-              <option value="from">From Status</option>
+            <select id="historyStatusToFilter" class="input-ubc w-56">
+              <option value="">All Statuses</option>
             </select>
           </div>
           <div>


### PR DESCRIPTION
## Summary

Replaced the old status and direction dropdown combo with two separate dropdowns on the change history tab. You can now filter by the status a student came from, the status they moved to, or set both to find a specific transition. Also added a result counter that shows up when any filter or search is active, same style as the applicants page.

## Changes

Backend updated the status history query to take status from and status to as separate params so both can be applied at the same time.

Frontend swapped out the old dropdowns for the two new ones, wired them up, and updated the result count to show which filters are active.

## Test plan

- [x] Go to statistics page and open the change history tab
- [x] Confirm status from and status to dropdowns are both showing all statuses
- [x] Select a status to filter only confirms rows where previous status matches
- [x] Select a status from filter only confirms rows where status reached matches
- [x] Select both and confirm only the exact transition shows
- [x] Confirm result count shows correctly with from and to labels
- [x] Confirm acceptance filter still works on its own