### PR TITLE
Fix session comparison timeline bugs and XSS

### DIFF
--- a/api/statistics.py
+++ b/api/statistics.py
@@ -37,6 +37,8 @@ def compare_timeline():
         return jsonify({"success": False, "message": "session_a and session_b are required"}), 400
     try:
         return jsonify({"success": True, **_svc.compare_sessions_timeline(session_a, session_b)}), 200
+    except ValueError as e:
+        return jsonify({"success": False, "message": str(e)}), 400
     except Exception as e:
         return jsonify({"success": False, "message": str(e)}), 500
 

--- a/services/statistics_service.py
+++ b/services/statistics_service.py
@@ -45,7 +45,7 @@ class StatisticsService:
         for m in range(1, 13):
             a_cutoff = date(a_year, m, 1) if a_year else None
             b_cutoff = date(b_year, m, 1) if b_year else None
-            if a_cutoff and a_cutoff > today and (b_cutoff is None or b_cutoff > today):
+            if (a_cutoff is None or a_cutoff > today) and (b_cutoff is None or b_cutoff > today):
                 break
             months.append({
                 "month": m,
@@ -97,8 +97,7 @@ class StatisticsService:
         applicants = _applicant_svc.get_all(session_id=session_id)
         if cutoff_month is not None:
             year = session.get("year")
-            cutoff = date(year, cutoff_month, 1) if year else None
-            applicants = self._filter_by_cutoff(applicants, cutoff)
+            applicants = self._filter_by_cutoff(applicants, date(year, cutoff_month, 1) if year else None)
         return {
             "id": session_id,
             "name": session.get("name", f"Session {session_id}"),
@@ -106,11 +105,18 @@ class StatisticsService:
         }
 
     @staticmethod
-    def _filter_by_cutoff(applicants: list, cutoff) -> list:
-        """Filter to applicants whose submit_date is on or before cutoff. No-op if cutoff is None."""
+    def _filter_by_cutoff(applicants: list, cutoff: date | None) -> list:
         if cutoff is None:
             return applicants
-        return [a for a in applicants if a.get("submit_date") and a["submit_date"] <= cutoff]
+        result = []
+        for a in applicants:
+            sd = a.get("submit_date")
+            if not sd:
+                continue
+            sd_date = sd.date() if hasattr(sd, "date") else sd
+            if sd_date <= cutoff:
+                result.append(a)
+        return result
 
     def _sessions_in_range(
         self, current_id: int, campus: str, year_from: int, year_to: int

--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -819,6 +819,8 @@ class StatisticsManager {
     btn?.classList.toggle("bg-ubc-blue", this.rangeMode);
     btn?.classList.toggle("text-white", this.rangeMode);
     btn?.classList.toggle("border-ubc-blue", this.rangeMode);
+    // Don't auto-fetch on toggle — range mode needs year inputs filled first.
+    // Two-session mode can re-fetch immediately since both selects already have values.
     if (!this.rangeMode) this.loadCompareData();
     else {
       const view = document.getElementById("compareStatsView");
@@ -860,7 +862,7 @@ class StatisticsManager {
       if (!data?.success) throw new Error(data?.message || "Failed to load");
       this._renderTimelineView(view, data);
     } catch (e) {
-      view.innerHTML = `<p class="text-red-500 text-sm p-4">${e.message}</p>`;
+      view.innerHTML = `<p class="text-red-500 text-sm p-4">${StatisticsManager._esc(e.message)}</p>`;
     }
   }
 
@@ -1010,9 +1012,9 @@ class StatisticsManager {
       .join("");
     container.innerHTML = `
       <div class="mb-3 flex items-center gap-2 flex-wrap">
-        <span class="inline-block text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-md bg-blue-50 text-blue-700 border border-blue-200">A — ${session_a.name}</span>
+        <span class="inline-block text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-md bg-blue-50 text-blue-700 border border-blue-200">A — ${StatisticsManager._esc(session_a.name)}</span>
         <span class="text-gray-300 font-bold">vs</span>
-        <span class="inline-block text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-md bg-amber-50 text-amber-700 border border-amber-200">B — ${session_b.name}</span>
+        <span class="inline-block text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-md bg-amber-50 text-amber-700 border border-amber-200">B — ${StatisticsManager._esc(session_b.name)}</span>
         <span class="text-xs text-gray-400 ml-1">submitted by 1st of month</span>
       </div>
       <div class="bg-white rounded-lg shadow overflow-x-auto">
@@ -1253,6 +1255,14 @@ class StatisticsManager {
       </svg>
       Loading comparison…
     </div>`;
+  }
+
+  static _esc(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
   }
 }
 


### PR DESCRIPTION
## Summary

- **Runtime crash**: `_filter_by_cutoff` compared `datetime` objects from psycopg2 against `date` objects, raising `TypeError` on any real data. Normalised to `date` before comparison.
- **Infinite loop / bad data**: Break condition in `compare_sessions_timeline` never fired when a session had no `year`, producing 12 identical month entries. Fixed to break only when both sessions are positively confirmed to be in the future.
- **Wrong HTTP status**: `compare_timeline` endpoint caught `ValueError` (invalid session ID) with the generic `Exception` handler, returning 500 instead of 400. Added explicit `ValueError → 400` handler to match the other endpoints.
- **XSS**: Session names and error messages were interpolated directly into `innerHTML`. Added `StatisticsManager._esc()` and applied it to all three vulnerable sites.
- **Deleted comment restored**: `toggleRangeMode` had an explanatory comment removed that documented non-obvious asymmetric fetch behaviour.

## Test plan

- [x] Timeline renders correct cumulative counts with two sessions that have years set
- [x] No crash when one or both sessions lack a `year`
- [x] Invalid session ID to `/api/statistics/compare-timeline` returns 400, not 500
- [x] Month cutoff filter produces correct applicant subsets